### PR TITLE
MLS.Bootstrap.Symbolic.State.KeyPackageStore: bump rlimit

### DIFF
--- a/fstar/bootstrap/symbolic/MLS.Bootstrap.Symbolic.State.KeyPackageStore.fst
+++ b/fstar/bootstrap/symbolic/MLS.Bootstrap.Symbolic.State.KeyPackageStore.fst
@@ -203,7 +203,7 @@ let initialize_key_package_store_proof #invs tr me =
   assert(is_well_formed _ (is_publishable tr) store)
 #pop-options
 
-#push-options "--fuel 1 --ifuel 1 --z3rlimit 25"
+#push-options "--fuel 1 --ifuel 1 --z3rlimit 50"
 val extend_key_package_store_proof:
   {|protocol_invariants|} ->
   tr:trace ->


### PR DESCRIPTION
This failed in check-world with

```
* Error 349 at ./fstar/bootstrap/symbolic/MLS.Bootstrap.Symbolic.State.KeyPackageStore.fst(224,2-242,11):
  - The verification condition succeeded after splitting it to localize
    potential errors, although the original non-split verification condition
    failed. If you want to rely on splitting queries for verifying your program
    please use the '--split_queries always' option rather than relying on it
    implicitly.
  - Also see: ./fstar/bootstrap/symbolic/MLS.Bootstrap.Symbolic.State.KeyPackageStore.fst(224,2-242,11)
```